### PR TITLE
Fix: 할 일 삭제가 되지 않는 버그 수정

### DIFF
--- a/Poptato_iOS/Poptato_iOS/Scene/Backlog/BacklogViewModel.swift
+++ b/Poptato_iOS/Poptato_iOS/Scene/Backlog/BacklogViewModel.swift
@@ -111,6 +111,7 @@ final class BacklogViewModel: ObservableObject {
         do {
             await MainActor.run {
                 self.backlogList.removeAll { $0.todoId == todoId }
+                selectedTodoItem = nil
             }
             
             try await backlogRepository.deleteBacklog(todoId: todoId)

--- a/Poptato_iOS/Poptato_iOS/Scene/Today/TodayViewModel.swift
+++ b/Poptato_iOS/Poptato_iOS/Scene/Today/TodayViewModel.swift
@@ -125,6 +125,7 @@ final class TodayViewModel: ObservableObject {
         do {
             await MainActor.run {
                 self.todayList.removeAll { $0.todoId == todoId }
+                selectedTodoItem = nil
             }
             
             try await backlogRepository.deleteBacklog(todoId: todoId)


### PR DESCRIPTION
- close #86 

## TODO

- [x] 오늘 페이지에서 할 일 삭제 후 selectedTodo를 nil로 초기화
- [x] 할 일 페이지에서 할 일 삭제 후 selectedTodo를 nil로 초기화